### PR TITLE
fix: Binary execution

### DIFF
--- a/bin/cdk-construct-init
+++ b/bin/cdk-construct-init
@@ -1,19 +1,23 @@
 #!/usr/bin/env node
 
-// Delegates to the compiled CLI. Prefer dist/index.js if present (packaged),
-// otherwise fall back to lib/index.js for local dev.
+// Execute the compiled CLI entry as the main module so its main() runs.
+// Prefer lib/index.js (what npm installs), fallback to dist/index.js for local dev.
 
 const { existsSync } = require('fs');
 const { join } = require('path');
+const { spawnSync } = require('child_process');
 
-const distEntry = join(__dirname, '..', 'dist', 'index.js');
 const libEntry = join(__dirname, '..', 'lib', 'index.js');
+const distEntry = join(__dirname, '..', 'dist', 'index.js');
 
-if (existsSync(distEntry)) {
-  require(distEntry);
-} else if (existsSync(libEntry)) {
-  require(libEntry);
-} else {
-  console.error('Unable to locate compiled entry. Tried dist/index.js and lib/index.js');
+const entry = existsSync(libEntry) ? libEntry : (existsSync(distEntry) ? distEntry : undefined);
+
+if (!entry) {
+  console.error('Unable to locate compiled entry. Tried lib/index.js and dist/index.js');
   process.exit(1);
 }
+
+const result = spawnSync(process.execPath, [entry, ...process.argv.slice(2)], {
+  stdio: 'inherit',
+});
+process.exit(result.status ?? 0);


### PR DESCRIPTION
 Execute the compiled CLI entry as the main module so its main() runs.